### PR TITLE
Allow user to inject a different payload

### DIFF
--- a/switch-boot.nix
+++ b/switch-boot.nix
@@ -20,6 +20,10 @@ in {
         type = types.bool;
         default = false;
       };
+      payload = mkOption {
+        type = types.path;
+        default = hekate;
+      };
     };
   };
   config = mkIf cfg.enable {
@@ -28,7 +32,7 @@ in {
       description = "Switch payload injector";
       serviceConfig = {
         # fusee-launcher and fusee-nano not working
-        ExecStart = "${pkgs.jre}/bin/java -jar ${pkgs.ns-usbloader}/share/java/ns-usbloader.jar -r ${hekate}";
+        ExecStart = "${pkgs.jre}/bin/java -jar ${pkgs.ns-usbloader}/share/java/ns-usbloader.jar -r ${cfg.payload}";
       };
     };
     services.udev.extraRules = ''


### PR DESCRIPTION
In case a different payload than hekate is wanted to be used, this can now be set using `services.switch-boot.payload`. By default, hekate will still be selected.